### PR TITLE
Correctly quote yaml in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ themable_grid:
   gap: 8px
   breakpoints:
     - name: mobile
-      mq: (max-width: 767px)
+      mq: '(max-width: 767px)'
       columns: 1
     - name: tablet
-      mq: (min-width: 768px) and (max-width: 1023px)
+      mq: '(min-width: 768px) and (max-width: 1023px)'
       columns: 2
     - name: desktop
-      mq: (min-width: 1024px)
+      mq: '(min-width: 1024px)'
       columns: 3
 ```
 


### PR DESCRIPTION
Users following this guide and copy/pasting into the editor will find that the yaml file cannot be saved as it contains syntax errors. Applying quotes to the lines containing a colon `:` maintains the intended behaviour, and allows a direct copy/paste from the documentation.